### PR TITLE
undefined method `customerorders'

### DIFF
--- a/lib/moysklad/resources/base.rb
+++ b/lib/moysklad/resources/base.rb
@@ -111,6 +111,6 @@ class Moysklad::Resources::Base
   end
 
   def prefix_path
-    PREFIX_PATH + self.class.type.downcase
+    PREFIX_PATH + self.class.type.split(/(?=[A-Z])/).join('_').downcase
   end
 end


### PR DESCRIPTION
when we call 
```universe.customer_orders.list``` because of downcasing it converts the name from "CustomerOrder" to "customerorder" and it's not correct. 
We receive undefined method `customerorders'

we should convert "CustomerOrder" to "customer_order"